### PR TITLE
Fix bridge build and enable CI for fix/* branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,10 @@
-# .drone.github/workflows/ci.yml
 name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches:
+      - main
+      - fix/**         # ← ★ ここを追加して、fix 系ブランチの push もトリガーに
   pull_request:
 
 jobs:
@@ -11,20 +12,25 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
       - uses: docker/setup-buildx-action@v3
+
       - uses: actions/cache@v3
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-buildx-
+
       - name: Build (no cache)
         run: docker compose build --no-cache
 
       - name: Up
         run: docker compose --profile cpu up -d
+
       - name: pytest
         run: docker compose exec -T rl-agent pytest -q /work/tests
+
       - name: Upload logs on failure
         if: failure()
         uses: actions/upload-artifact@v4

--- a/docker/px4-bridge/Dockerfile.bridge
+++ b/docker/px4-bridge/Dockerfile.bridge
@@ -51,8 +51,8 @@ http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" \
         > /etc/apt/sources.list.d/ros2.list && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
-        ros-humble-ros-gz-bridge && \
-        ros-humble-rosidl-default-runtime \
+        ros-humble-ros-gz-bridge \
+        ros-humble-rosidl-default-runtime && \
     rm -rf /var/lib/apt/lists/*
 
 # ── copy artefacts & entrypoint ──

--- a/docker/px4-bridge/Dockerfile.bridge
+++ b/docker/px4-bridge/Dockerfile.bridge
@@ -19,6 +19,7 @@ http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" \
     apt-get update && \
     apt-get install -y --no-install-recommends \
         ros-humble-ros-gz-bridge \
+        ros-humble-rosidl-default-generators \
         python3-colcon-common-extensions \
         build-essential && \
     rm -rf /var/lib/apt/lists/*
@@ -51,6 +52,7 @@ http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" \
     apt-get update && \
     apt-get install -y --no-install-recommends \
         ros-humble-ros-gz-bridge && \
+        ros-humble-rosidl-default-runtime \
     rm -rf /var/lib/apt/lists/*
 
 # ── copy artefacts & entrypoint ──

--- a/drone_msgs/package.xml
+++ b/drone_msgs/package.xml
@@ -7,6 +7,7 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>rosidl_default_generators</buildtool_depend>
   <!-- 追加: ROS2 のメッセージ生成用依存関係 -->
   <build_depend>rosidl_default_generators</build_depend>
   <build_depend>geometry_msgs</build_depend>

--- a/src/outer_motor_bridge/setup.py
+++ b/src/outer_motor_bridge/setup.py
@@ -1,19 +1,18 @@
+# src/outer_motor_bridge/setup.py
 from setuptools import setup
-package_name = "outer_motor_bridge"
 
 setup(
-    name=package_name,
-    version="0.0.1",
-    packages=[package_name],
-    install_requires=["setuptools"],
-    zip_safe=True,
-    maintainer="you",
-    maintainer_email="user@example.com",
-    description="Republish PX4 ActuatorMotors (outer rotors) for logging",
-    license="Apache-2.0",
+    name="outer_motor_bridge",
+    version="0.1.0",
+    py_modules=["outer_motor_bridge"],   # ★ここ
+    data_files=[
+        ("share/ament_index/resource_index/packages", ["resource/outer_motor_bridge"]),
+        ("share/outer_motor_bridge", ["package.xml"]),
+    ],
+    install_requires=["setuptools", "rclpy"],
     entry_points={
         "console_scripts": [
-            "outer_motor_bridge = outer_motor_bridge.outer_motor_bridge:main",
+            "outer_motor_bridge_node = outer_motor_bridge:main",
         ],
     },
 )


### PR DESCRIPTION
### Summary
- outer_motor_bridge の resource マーカーファイルを追加
- runtime ステージの apt コマンド構文ミスを修正
- fix/** ブランチでも CI が走るよう `ci.yml` を整備

### Test Plan
- GitHub Actions にて自動テストが走ることを確認予定
- `docker compose build` および pytest 実行がすべて正常に完了すること

### Notes
- 将来的に fix/* 以外のブランチ（e.g. feature/*）も対応したい場合は `ci.yml` を調整する
